### PR TITLE
Week1: Refactor ComputerBuilder for Enhanced Flexibility

### DIFF
--- a/week1/computer.py
+++ b/week1/computer.py
@@ -15,18 +15,26 @@ class Computer:
         }
     
 class ComputerBuilder:
-    @staticmethod
-    def build_computer(type):
-        if type == "laptop":
-            cpu = CPUFactory.make_cpu(type="single")
-            ram = RamFactory.make_memory(size=8)
-            rom = RomFactory.make_memory(data=[1, 2, 3, 4])
-        elif type == "desktop":
-            cpu = CPUFactory.make_cpu(type="dual")
-            ram = RamFactory.make_memory(size=16)
-            rom = RomFactory.make_memory(data=[1, 2, 3, 4, 5, 6, 7, 8])
-        else:
-            raise ValueError("Invalid computer type :", type)
-        
-        return Computer(cpu=cpu, ram=ram, rom=rom)
+    def __init__(self):
+        self.cpu = None
+        self.ram = None
+        self.rom = None
+
+    def set_cpu(self, type):
+        self.cpu = CPUFactory.make_cpu(type=type)
+        return self
+
+    def set_ram(self, size):
+        self.ram = RamFactory.make_memory(size=size)
+        return self
+
+    def set_rom(self, data):
+        self.rom = RomFactory.make_memory(data=data)
+        return self
+
+    def build(self):
+        if not self.cpu or not self.ram or not self.rom:
+            raise ValueError("Missing components for Computer construction")
+        return Computer(cpu=self.cpu, ram=self.ram, rom=self.rom)
+
     

--- a/week1/tests/test_computer.py
+++ b/week1/tests/test_computer.py
@@ -7,22 +7,25 @@ from cpu import CPUFactory
 @pytest.mark.computer
 class TestComputer:
     def test_laptop(self):
-        computer = ComputerBuilder.build_computer(type="laptop")
+        builder = ComputerBuilder()
+        computer = builder.set_cpu(type="single").set_ram(size=8).set_rom(data=[1, 2, 3, 4]).build()
         state = computer.bootstrap()
         assert state["cpu_processed"] == [[1, 2, 3, 4]]
         assert state["ram_data"] == [0] * 8
         assert state["rom_data"] == [1, 2, 3, 4]
 
     def test_desktop(self):
-        computer = ComputerBuilder.build_computer(type="desktop")
+        builder = ComputerBuilder()
+        computer = builder.set_cpu(type="dual").set_ram(size=16).set_rom(data=[1, 2, 3, 4, 5, 6, 7, 8]).build()
         state = computer.bootstrap()
         assert state["cpu_processed"] == [[1, 3, 5, 7], [2, 4, 6, 8]]
         assert state["ram_data"] == [0] * 16
         assert state["rom_data"] == [1, 2, 3, 4, 5, 6, 7, 8]
 
     def test_invalid_computer(self):
+        builder = ComputerBuilder()
         with pytest.raises(ValueError):
-            ComputerBuilder.build_computer(type="invalid")
+            computer = builder.build()
 
 
 @pytest.mark.memory


### PR DESCRIPTION
>하나만 더 커멘트하자면 보통 빌더는 객체 생성 후에 build method를 호출합니다. 그 때의 장점은 build를 하든 안하든 optional로 다룰 수 있다는거죠. 지금 준홍님은 모든 private attribute를 전부 선언 이후에 객체를 한번에 생성해버려서 build 자체가 required인 느낌이라 빌더 패턴의 장점을 제대로 못 살리긴 해요 참고해보세요

Reflect that comment